### PR TITLE
Observable create pattern for async calls

### DIFF
--- a/Source/RxPermission.swift
+++ b/Source/RxPermission.swift
@@ -25,61 +25,11 @@ import Permission
 import RxSwift
 
 public extension Permission {
-    /// Reactive wrapper for `Permission` instance.
-    public var rx_permission: Observable<PermissionStatus> {
-        return rx_permissionInstance.asObservable()
+
+  public var rx_permission: Observable<PermissionStatus> {
+    return Observable.create { (observer) in
+      self.request { observer.onNext($0) }
+      return AnonymousDisposable { observer.onCompleted() }
     }
-}
-
-// MARK: - Permission
-
-extension Permission: AssociatedObject {
-    private var rx_permissionInstance: PublishSubject<PermissionStatus> {
-        get {
-            var permission: PublishSubject<PermissionStatus>!
-            
-            doLocked {
-                if let lookup = self.associatedObject(&.permission) as? PublishSubject<PermissionStatus> {
-                    permission = lookup
-                } else {
-                    permission = PublishSubject<PermissionStatus>()
-                    self.request { permission.onNext($0) }
-                    self.rx_permissionInstance = permission
-                }
-            }
-            
-            return permission
-        }
-        
-        set {
-            doLocked {
-                self.associatedObject(&.permission, object: newValue)
-            }
-        }
-    }
-    
-    private func doLocked(closure: () -> Void) {
-        objc_sync_enter(self); defer { objc_sync_exit(self) }
-        closure()
-    }
-}
-
-// MARK: - AssociatedObject
-
-private protocol AssociatedObject {}
-
-private extension AssociatedObject where Self: AnyObject {
-    func associatedObject(inout key: String) -> AnyObject! {
-        return objc_getAssociatedObject(self, &key)
-    }
-    
-    func associatedObject(inout key: String, object: AnyObject) {
-        objc_setAssociatedObject(self, &key, object, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
-}
-
-// MARK: - String
-
-private extension String {
-    static var permission = "rx_permissionInstance"
+  }
 }


### PR DESCRIPTION
Your code seemed to be over engineered in regards to how observables work.

I refactored it into a Observable.create pattern for async usage.

I only noticed this because when subscribing to the event, it would only trigger once per permission instance, making flatMap usage quite limited.

e.g. usage:

``` swift
locationButton.rx_tap
      .flatMap {
        return Permission.LocationAlways.rx_permission
      }.subscribeNext { status in
        print(status)
      }.addDisposableTo(rx_disposeBag)
```
